### PR TITLE
fix: accept suffix dtype in DM05 CUDA graph time conditioning

### DIFF
--- a/opendm/model/dm05/dm05_arch.py
+++ b/opendm/model/dm05/dm05_arch.py
@@ -1522,6 +1522,7 @@ class DM05ForConditionalGeneration(DMPreTrainedModel):
     def _build_adarms_cond(
         self,
         time: torch.Tensor,
+        dtype: torch.dtype | None = None,
     ) -> torch.Tensor:
         ae_hidden = self.model.action_in_proj.out_features
         if self.precision_policy == FP32_MIXED_PRECISION_POLICY:
@@ -1531,7 +1532,7 @@ class DM05ForConditionalGeneration(DMPreTrainedModel):
             cond = linear_fp32(cond, self.model.time_mlp_out)
             return F.silu(cond)
 
-        dtype = self.model.time_mlp_in.weight.dtype
+        dtype = self.model.time_mlp_in.weight.dtype if dtype is None else dtype
         time_emb = posemb_sincos(time, ae_hidden, max_period=4.0).to(dtype)
         cond = self.model.time_mlp_in(time_emb)
         cond = F.silu(cond)

--- a/tests/test_dm05_adarms_cond.py
+++ b/tests/test_dm05_adarms_cond.py
@@ -1,0 +1,83 @@
+"""CPU regression coverage for the suffix graph's time-conditioning call."""
+
+from types import MethodType, SimpleNamespace
+
+import pytest
+import torch
+
+from opendm.constants.precision import (
+    BF16_MIXED_PRECISION_POLICY,
+    FP32_MIXED_PRECISION_POLICY,
+)
+from opendm.model.dm05.dm05_arch import DM05ForConditionalGeneration
+
+
+def _tiny_conditioner(dtype, precision_policy=BF16_MIXED_PRECISION_POLICY):
+    """Bind the production method without constructing a VLM or action expert."""
+    hidden_size = 8
+    layers = [
+        torch.nn.Linear(hidden_size, hidden_size, device="cpu", dtype=dtype)
+        for _ in range(2)
+    ]
+    with torch.no_grad():
+        for layer in layers:
+            layer.weight.fill_(0.125)
+            layer.bias.fill_(0.0625)
+    model = SimpleNamespace(
+        action_in_proj=SimpleNamespace(out_features=hidden_size),
+        time_mlp_in=layers[0],
+        time_mlp_out=layers[1],
+    )
+    owner = SimpleNamespace(model=model, precision_policy=precision_policy)
+    owner._build_adarms_cond = MethodType(
+        DM05ForConditionalGeneration._build_adarms_cond, owner
+    )
+    return owner
+
+
+def test_build_adarms_cond_accepts_explicit_suffix_dtype():
+    model = _tiny_conditioner(torch.float32)
+    time = torch.tensor([0.2, 0.8], device="cpu")
+    input_dtypes = []
+    hook = model.model.time_mlp_in.register_forward_pre_hook(
+        lambda module, inputs: input_dtypes.append(inputs[0].dtype)
+    )
+    try:
+        with torch.autocast(device_type="cpu", dtype=torch.bfloat16):
+            # _run_suffix_graph_step passes the suffix dtype positionally.
+            actual = model._build_adarms_cond(time, torch.bfloat16)
+    finally:
+        hook.remove()
+
+    assert input_dtypes == [torch.bfloat16]
+    assert actual.shape == (2, 8)
+    assert actual.dtype == torch.bfloat16
+    assert torch.isfinite(actual).all()
+
+
+@pytest.mark.parametrize("weight_dtype", [torch.float32, torch.bfloat16])
+def test_build_adarms_cond_legacy_call_uses_weight_dtype(weight_dtype):
+    model = _tiny_conditioner(weight_dtype)
+    time = torch.tensor([0.2, 0.8], device="cpu")
+
+    actual = model._build_adarms_cond(time)
+    explicit_default = model._build_adarms_cond(time, dtype=None)
+
+    assert actual.shape == (2, 8)
+    assert actual.dtype == weight_dtype
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual, explicit_default, rtol=0, atol=0)
+
+
+def test_build_adarms_cond_fp32_mixed_preserves_fp32_under_autocast():
+    model = _tiny_conditioner(torch.float32, FP32_MIXED_PRECISION_POLICY)
+    time = torch.tensor([0.2, 0.8], device="cpu")
+    reference = model._build_adarms_cond(time)
+
+    with torch.autocast(device_type="cpu", dtype=torch.bfloat16):
+        actual = model._build_adarms_cond(time, torch.bfloat16)
+
+    assert actual.shape == (2, 8)
+    assert actual.dtype == torch.float32
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual, reference, rtol=0, atol=0)


### PR DESCRIPTION
## Summary

Fix a Python argument mismatch that prevents DM05 suffix CUDA Graph capture with the default inference backend.

`_run_suffix_graph_step()` calls:

```python
self._build_adarms_cond(profile.time, suffix_embeds.dtype)
```

However, `DM05ForConditionalGeneration._build_adarms_cond()` only accepts `time`. The first warmup iteration in `_capture_suffix_graph_profile()` raises:

```text
TypeError: DM05ForConditionalGeneration._build_adarms_cond()
takes 2 positional arguments but 3 were given
```

This happens before entering `torch.cuda.graph()`. `_run_suffix_graph()` catches the exception, disables the affected profile, and falls back to eager suffix decoding. Inference still succeeds, making the missing graph acceleration easy to overlook.

## Change

- Add the optional `dtype: torch.dtype | None = None` argument.
- Retain the time-MLP weight dtype when the argument is omitted or `None`.
- Leave the `fp32_mixed` branch unchanged.

This matches the existing helper in `opendm/infer/dm05_infer_arch.py` and preserves single-argument eager/training callers.

## Validation

- CPU regression tests directly exercise the production helper with small Linear layers; no checkpoint or GPU is required for those tests.
- `python -m pytest -q -p no:cacheprovider tests/test_dm05_adarms_cond.py`: **4 passed** on the fix. Running the same tests against unmodified `c4762fe` produces **4 failures** due to the missing `dtype` parameter (including the positional call used by the graph path).
- The same two-line implementation change was exercised with DM05-LIBERO BF16 on an RTX 4090 D: the capture path completed and subsequent requests used the graph-enabled path, without the signature-error fallback.

No checkpoint, model configuration, action normalization, or diffusion-step setting is changed.
